### PR TITLE
Require google-cloud-storage >= 1.62 and googleauth >= 1.17.3

### DIFF
--- a/saral_uploader_ext.gemspec
+++ b/saral_uploader_ext.gemspec
@@ -23,8 +23,9 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.0.6"
-  spec.add_dependency "google-cloud-storage"
+  spec.add_dependency "google-cloud-storage", ">= 1.62"
   spec.add_dependency "google-apis-iamcredentials_v1"
+  spec.add_dependency "googleauth", ">= 1.17.3"
   spec.add_dependency "mime-types"
 
   spec.post_install_message = "Thanks for installing saral-uploader-ext. Please set environment variable mentioned in README.md"


### PR DESCRIPTION
## Summary
- Pins the version floor this gem's IAM signBlob-based `signer_options` (in `upload_service.rb`) actually needs.
- Mirrors the same version bump already applied on the consuming app side in [jarvisconsulting/doc-collection#10141](https://github.com/jarvisconsulting/doc-collection/pull/10141), so a plain `bundle install` of this gem resolves a consistent, working Google Cloud dependency set instead of risking an older `google-cloud-storage`/`googleauth` combo.

## Test plan
- [x] `bundle install` in this repo resolves cleanly with the new floors (google-cloud-storage 1.62.0, googleauth 1.17.3, google-apis-storage_v1 0.65.0).
- [x] Verified `generate_upload_signed_url` succeeds end-to-end when this gem is consumed via a local path from doc-collection with these versions installed.