### PR TITLE
Use skip_lookup on bucket init to avoid get_bucket keyword conflict

### DIFF
--- a/lib/saral_uploader_ext/services/upload_service.rb
+++ b/lib/saral_uploader_ext/services/upload_service.rb
@@ -17,8 +17,14 @@ module SaralUploaderExt
       raise CustomError.new('Gcloud project ID must be present', "'G_CLOUD_PROJECT_ID' missing") unless @gcloud_project_id.present?
 
       @storage = Google::Cloud::Storage.new(project_id: @gcloud_project_id)
-      @bucket = @storage.bucket(@bucket_name)
-      raise 'Bucket not found' if @bucket.nil?
+      # skip_lookup avoids an upfront `buckets.get` call. That call goes through
+      # Google::Cloud::Storage::Service#get_bucket, which passes `generation:`/
+      # `soft_deleted:` keywords that raise ArgumentError when the legacy
+      # `google-api-client` gem's bundled (older) storage_v1 client shadows the
+      # one this gem depends on. Bucket existence still gets verified implicitly
+      # the first time an actual operation (signed_url, create_file, delete) hits
+      # the API.
+      @bucket = @storage.bucket(@bucket_name, skip_lookup: true)
     end
 
     def generate_upload_signed_url(file_name:, bucket_path:, expiration_time: nil, max_file_size_in_mb: nil)


### PR DESCRIPTION
## Summary
- `UploadService#initialize` called `@storage.bucket(@bucket_name)` without `skip_lookup: true`, which internally calls `service.get_bucket(..., generation:, soft_deleted:)`.
- When the consuming app (doc-collection) also has the legacy `google-api-client` gem installed, its bundled (older) `storage_v1` client can win the Ruby require race and shadow the one this gem actually depends on — whose `get_bucket` doesn't declare those keywords. Result: `ArgumentError: unknown keywords: :soft_deleted, :generation`.
- `skip_lookup: true` avoids that upfront lookup entirely (matches the pattern already used elsewhere in doc-collection, e.g. `GcloudStorageHelper`-based calls in `reports_helper.rb`). Bucket existence still gets verified implicitly the first time `signed_url`/`create_file`/`delete` actually hits the API.
- Dropped the now-dead `raise 'Bucket not found' if @bucket.nil?` check — `skip_lookup: true` never returns `nil`.

## Test plan
- [x] Verified `generate_upload_signed_url` succeeds against a real bucket with this gem consumed via a local path from doc-collection, **with `google-api-client` intentionally re-added** to the host app's Gemfile to reproduce the conflict — confirmed it now works despite that gem's presence.